### PR TITLE
Minor component updates

### DIFF
--- a/src/components/ImageUpload.tsx
+++ b/src/components/ImageUpload.tsx
@@ -14,7 +14,7 @@ export type ImageUploadProps = {
   helperText?: string;
   errorText?: string;
   error?: boolean;
-  variant: 'large';
+  variant: 'large' | 'medium';
   fullWidth?: boolean;
   src?: string;
   uploading?: boolean;
@@ -64,7 +64,7 @@ export function ImageUpload(props: ImageUploadProps) {
           {props.helperText}
         </Typography>
       )}
-      {props.variant === 'large' && (
+      {(props.variant === 'large' || props.variant === 'medium') && (
         <>
           {props.errorText && (
             <Flex gap={theme.spacing(0.5)} align="center">
@@ -83,7 +83,7 @@ export function ImageUpload(props: ImageUploadProps) {
             onClick={props.canUpload ? onUpload.bind(null, props.onSelect) : undefined}
           >
             {props.src && props.uploading && (
-              <LoaderIconWrapper>
+              <LoaderIconWrapper variant={props.variant}>
                 <Icon icon="Loader2" color="lightWhite" size="24" />
               </LoaderIconWrapper>
             )}
@@ -133,10 +133,17 @@ const Spacer = styled('div')<{ size: number }>(({ theme, size }) => ({
   width: '100%',
 }));
 
-const LoaderIconWrapper = styled('div')`
+const VariantToWrapperSize: Record<ImageUploadProps['variant'], number> = {
+  large: 50,
+  medium: 30,
+};
+
+const LoaderIconWrapper = styled('div')<{
+  variant: ImageUploadProps['variant'];
+}>`
   height: 100%;
   width: 100%;
-  max-height: 150px;
+  max-height: ${({ variant }) => VariantToWrapperSize[variant]}px;
   display: flex;
   position: absolute;
   justify-content: center;

--- a/src/components/TextArea/index.tsx
+++ b/src/components/TextArea/index.tsx
@@ -4,10 +4,13 @@ import { Typography } from '../Typography';
 import { OutlinedTextFieldProps } from '@mui/material';
 import { useCallback } from 'react';
 
-export type TextAreaProps = TextInputProps &
+export type TextAreaProps = Omit<TextInputProps, 'multiline'> &
   Omit<OutlinedTextFieldProps, 'variant'> & {
     maxCharacter: number;
     hideTextCount?: boolean;
+    resize?: React.CSSProperties['resize'];
+    minHeight?: React.CSSProperties['minHeight'];
+    maxHeight?: React.CSSProperties['maxHeight'];
   };
 
 export const TextArea = (props: TextAreaProps) => {
@@ -24,7 +27,20 @@ export const TextArea = (props: TextAreaProps) => {
 
   return (
     <Flex direction="column" gap={4} width={fullWidth ? '100%' : undefined}>
-      <TextInput {...props} fullWidth={fullWidth} multiline value={props.value} onChange={handleTextChange} />
+      <TextInput
+        {...props}
+        fullWidth={fullWidth}
+        multiline
+        value={props.value}
+        onChange={handleTextChange}
+        sx={{
+          '& textarea': {
+            resize: props.resize,
+            minHeight: props.minHeight ?? 15,
+            maxHeight: props.maxHeight,
+          },
+        }}
+      />
       {(!props.hideTextCount || !props.maxCharacter) && (
         <Typography class="medium" size="base" color={props.errorText ? 'error75' : 'dark90'}>
           {characterCount}/{props.maxCharacter} characters


### PR DESCRIPTION
- added size related props to `TextArea`
  - [`resize`](https://developer.mozilla.org/en-US/docs/Web/CSS/resize) - allows to control whether the text area can be resized
  - `minHeight` - to control the minimum height of the component
  - `maxHeight` - to control the maximum height of the component
- added a `medium` variant to `ImageUpload`