### PR TITLE
task / Tabler improvements

### DIFF
--- a/src/__tests__/components/Icon.test.tsx
+++ b/src/__tests__/components/Icon.test.tsx
@@ -1,0 +1,36 @@
+import { render } from '@testing-library/react';
+
+import { Icon } from '../../components/Icon';
+import { GameIconsPerson, PDF, ExclamationCircle, SquareRoundedChevronDownFilled } from '../../components/Icon/Custom';
+import { ThemedApp } from '../../stories/styles';
+
+describe('Icon', () => {
+  test('renders custom PDF icon', () => {
+    render(
+      <ThemedApp>
+        <Icon icon={PDF} color="dark100" />
+      </ThemedApp>
+    );
+  });
+  test('renders custom GameIconsPerson icon', () => {
+    render(
+      <ThemedApp>
+        <Icon icon={GameIconsPerson} color="dark100" />
+      </ThemedApp>
+    );
+  });
+  test('renders custom ExclamationCircle icon', () => {
+    render(
+      <ThemedApp>
+        <Icon icon={ExclamationCircle} color="dark100" />
+      </ThemedApp>
+    );
+  });
+  test('renders custom SquareRoundedChevronDownFilled icon', () => {
+    render(
+      <ThemedApp>
+        <Icon icon={SquareRoundedChevronDownFilled} color="dark100" />
+      </ThemedApp>
+    );
+  });
+});

--- a/src/components/Button/IconButton.tsx
+++ b/src/components/Button/IconButton.tsx
@@ -3,7 +3,7 @@ import type React from 'react';
 
 import { type ButtonProps as MuiButtonProps } from '@mui/material';
 
-import { Icon, type IconProps } from '../Icon';
+import { Icon, type IconComponent } from '../Icon';
 
 import { ButtonWrapper } from './styles';
 import { useButtonStyles, useButtonFontStyle } from './utils';
@@ -13,7 +13,7 @@ export type IconButtonProps = Omit<MuiButtonProps, 'variant' | 'type' | 'size' |
   type: 'mint' | 'destructive' | 'disabled';
   size: 'lg' | 'md' | 'sm';
   wrap: 'wide' | 'narrow';
-  icon: IconProps['icon'];
+  icon: IconComponent;
 };
 
 const IconButtonNoMemo: React.FC<IconButtonProps> = ({

--- a/src/components/Button/index.tsx
+++ b/src/components/Button/index.tsx
@@ -3,7 +3,7 @@ import type React from 'react';
 
 import { type ButtonProps as MuiButtonProps } from '@mui/material';
 
-import { Icon, type IconProps } from '../Icon';
+import { Icon, type IconComponent } from '../Icon';
 import { Typography } from '../Typography';
 
 import { ButtonWrapper } from './styles';
@@ -14,8 +14,8 @@ export type ButtonProps = Omit<MuiButtonProps, 'variant' | 'type' | 'size' | 'ch
   type: 'mint' | 'destructive' | 'disabled';
   size: 'lg' | 'md' | 'sm';
   wrap: 'wide' | 'narrow';
-  leadingIcon?: IconProps['icon'];
-  trailingIcon?: IconProps['icon'];
+  leadingIcon?: IconComponent;
+  trailingIcon?: IconComponent;
 };
 
 const ButtonNoMemo: React.FC<ButtonProps> = ({

--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -2,17 +2,18 @@ import { memo } from 'react';
 import type React from 'react';
 
 import { styled, useTheme } from '@mui/material';
+import { Pencil } from 'tabler-icons-react';
 
 import { Button } from './Button';
 import { Flex } from './Flex';
-import { type IconProps } from './Icon';
+import { type IconComponent } from './Icon';
 import { LinkButton } from './LinkButton';
 import { Typography } from './Typography';
 
 type CardButtonsProps = {
   editing: boolean;
 
-  editButtonIcon?: IconProps['icon'];
+  editButtonIcon?: IconComponent;
   editButtonTitle?: string;
   saveButtonTitle?: string;
   cancelButtonTitle?: string;
@@ -74,7 +75,7 @@ export function Card(props: CardProps) {
 function CardButtonsNoMemo(props: CardButtonsProps) {
   const theme = useTheme();
   const {
-    editButtonIcon = 'Pencil',
+    editButtonIcon = Pencil,
     editButtonTitle = 'Update',
     cancelButtonTitle = 'Cancel',
     saveButtonTitle = 'Save changes',

--- a/src/components/Checkbox.tsx
+++ b/src/components/Checkbox.tsx
@@ -1,6 +1,7 @@
 import type React from 'react';
 
 import { Checkbox as CheckboxMui, FormControlLabel, styled, useTheme } from '@mui/material';
+import { Check, Minus } from 'tabler-icons-react';
 
 import { Flex } from './Flex';
 import { Icon } from './Icon';
@@ -63,12 +64,12 @@ export const RawCheckbox = (
     indeterminate={props.indeterminate ?? false}
     checkedIcon={
       <IconWrapper size={props.size} disabled={props.disabled ?? false}>
-        <Icon icon="Check" size={SIZE_TO_ICON_SIZE[props.size] - 2} color={props.disabled ? 'dark30' : 'lightWhite'} />
+        <Icon icon={Check} size={SIZE_TO_ICON_SIZE[props.size] - 2} color={props.disabled ? 'dark30' : 'lightWhite'} />
       </IconWrapper>
     }
     indeterminateIcon={
       <IconWrapper size={props.size} disabled={props.disabled ?? false}>
-        <Icon icon="Minus" size={SIZE_TO_ICON_SIZE[props.size] - 2} color={props.disabled ? 'dark30' : 'lightWhite'} />
+        <Icon icon={Minus} size={SIZE_TO_ICON_SIZE[props.size] - 2} color={props.disabled ? 'dark30' : 'lightWhite'} />
       </IconWrapper>
     }
     icon={<EmptyIcon className="BYB-Checkbox-Empty" size={props.size} />}

--- a/src/components/DatePicker/index.tsx
+++ b/src/components/DatePicker/index.tsx
@@ -4,6 +4,7 @@ import { useCallback, useMemo, useState } from 'react';
 import { useTheme } from '@mui/material';
 import { type DateView } from '@mui/x-date-pickers';
 import moment, { type Moment } from 'moment';
+import { CalendarEvent } from 'tabler-icons-react';
 
 import { Flex } from '../Flex';
 import { Icon } from '../Icon';
@@ -185,7 +186,7 @@ export const DatePicker: React.FC<DatePickerProps> = ({
           layout: props => <CalendarFooter toggleCalendar={toggleOpen}>{props.children}</CalendarFooter>,
           openPickerIcon: () => (
             <Flex onClick={toggleOpen}>
-              <Icon icon="CalendarEvent" color="dark75" size={24} />
+              <Icon icon={CalendarEvent} color="dark75" size={24} />
             </Flex>
           ),
           calendarHeader: () => (

--- a/src/components/DatePicker/styles.tsx
+++ b/src/components/DatePicker/styles.tsx
@@ -1,6 +1,11 @@
 import { Paper, styled } from '@mui/material';
 import { DatePicker } from '@mui/x-date-pickers';
 import { type Moment } from 'moment';
+import {
+  ChevronLeft as ChevronLeftIcon,
+  ChevronRight as ChevronRightIcon,
+  ChevronDown as ChevronDownIcon,
+} from 'tabler-icons-react';
 
 import { Flex } from '../Flex';
 import { Icon } from '../Icon';
@@ -12,7 +17,7 @@ type ChevronProps = {
 const ChevronLeft: React.FC<ChevronProps> = ({ onClick }) => {
   return (
     <Flex onClick={onClick} style={{ cursor: 'pointer' }}>
-      <Icon icon="ChevronLeft" color="dark90" size={16} />
+      <Icon icon={ChevronLeftIcon} color="dark90" size={16} />
     </Flex>
   );
 };
@@ -20,7 +25,7 @@ const ChevronLeft: React.FC<ChevronProps> = ({ onClick }) => {
 const ChevronRight: React.FC<ChevronProps> = ({ onClick }) => {
   return (
     <Flex onClick={onClick} style={{ cursor: 'pointer' }}>
-      <Icon icon="ChevronRight" color="dark90" size={16} />
+      <Icon icon={ChevronRightIcon} color="dark90" size={16} />
     </Flex>
   );
 };
@@ -28,7 +33,7 @@ const ChevronRight: React.FC<ChevronProps> = ({ onClick }) => {
 const ChevronDown: React.FC<ChevronProps> = ({ onClick }) => {
   return (
     <Flex onClick={onClick} style={{ cursor: 'pointer' }}>
-      <Icon icon="ChevronDown" color="dark90" size={16} />
+      <Icon icon={ChevronDownIcon} color="dark90" size={16} />
     </Flex>
   );
 };

--- a/src/components/DocumentUploadCard/RightContent/Locked.tsx
+++ b/src/components/DocumentUploadCard/RightContent/Locked.tsx
@@ -5,9 +5,12 @@
 // Components
 import type React from 'react';
 
+import { File, FileOff } from 'tabler-icons-react';
+
 import { typedMemo } from '../../../utils';
 import { Flex } from '../../Flex';
 import { Icon } from '../../Icon';
+import { PDF } from '../../Icon/Custom';
 import { Typography } from '../../Typography';
 // Utils
 
@@ -21,7 +24,7 @@ const LockedNoMemo: React.FC<LockedProps> = ({ fileUrl, fileName, fileSize = '-'
   if (!fileUrl) {
     return (
       <Flex direction="row" justify="center" align="center" grow={1}>
-        <Icon icon="FileOff" size="18" color="dark75" />
+        <Icon icon={FileOff} size="18" color="dark75" />
         <Typography class="medium" size="sm" color="dark75">
           No saved document
         </Typography>
@@ -32,7 +35,7 @@ const LockedNoMemo: React.FC<LockedProps> = ({ fileUrl, fileName, fileSize = '-'
   return (
     <Flex direction="row" width="100%" justify="space-between" align="center">
       <Flex direction="row" grow={1} align="center" gap={12}>
-        <Icon icon={fileUrl.endsWith('.pdf') ? 'PDF' : 'File'} size={18} color="dark75" />
+        <Icon icon={fileUrl.endsWith('.pdf') ? PDF : File} size={18} color="dark75" />
         <a href={fileUrl} target="_blank" rel="noreferrer" style={{ textDecoration: 'none' }}>
           <Typography class="medium" size="sm" color="dark75" padding={0}>
             {fileName}

--- a/src/components/DocumentUploadCard/RightContent/Upload.tsx
+++ b/src/components/DocumentUploadCard/RightContent/Upload.tsx
@@ -5,9 +5,11 @@ import type React from 'react';
 
 // Styled
 import { styled } from '@mui/material';
+import { Upload as UploadIcon } from 'tabler-icons-react';
 
 // Relative Imports
 // Utils
+
 import { typedMemo } from '../../../utils';
 // Components
 import { Button } from '../../Button';
@@ -47,7 +49,7 @@ const UploadNoMemo: React.FC<UploadProps> = ({
         <Button
           disabled
           title="Upload file"
-          leadingIcon="Upload"
+          leadingIcon={UploadIcon}
           variant="secondary"
           wrap="narrow"
           type="mint"

--- a/src/components/DocumentUploadCard/RightContent/Uploaded.tsx
+++ b/src/components/DocumentUploadCard/RightContent/Uploaded.tsx
@@ -4,6 +4,7 @@ import { useState, useCallback } from 'react';
 import type React from 'react';
 
 import { useTheme } from '@mui/material';
+import { Trash } from 'tabler-icons-react';
 
 import { typedMemo } from '../../../utils';
 import { Button } from '../../Button';
@@ -31,7 +32,7 @@ const UploadedNoMemo: React.FC<UploadedProps> = ({ onFileDelete }) => {
     return (
       <Flex direction="column" justify="center" alignSelf="stretch">
         <span onClick={toggleConfirmDelete}>
-          <Icon icon="Trash" size={18} color="dark90" />
+          <Icon icon={Trash} size={18} color="dark90" />
         </span>
       </Flex>
     );

--- a/src/components/DocumentUploadCard/index.tsx
+++ b/src/components/DocumentUploadCard/index.tsx
@@ -1,9 +1,9 @@
-// Relative Imports
-// Components
+import { CloudUpload, File } from 'tabler-icons-react';
+
 import { Flex } from '../../components/Flex';
 import { Icon } from '../../components/Icon';
 import { Typography } from '../../components/Typography';
-// Styled Components
+import { PDF } from '../Icon/Custom';
 import { TextFieldLabel } from '../TextInput/Labels';
 
 import { LeftContent } from './LeftContent';
@@ -45,7 +45,7 @@ export const DocumentUploadCard: React.FC<DocumentUploadCardProps> = ({
   onFileSelect,
   onFileDelete,
 }) => {
-  const fileIcon = fileUrl?.endsWith('.pdf') ? 'PDF' : 'File';
+  const fileIcon = fileUrl?.endsWith('.pdf') ? PDF : File;
   return (
     <Flex direction="column" width="100%">
       <TypographyContainer>
@@ -76,11 +76,7 @@ export const DocumentUploadCard: React.FC<DocumentUploadCardProps> = ({
         {isEditing && (
           <Flex direction="row" grow={1} gap={12}>
             <Flex direction="column" align="center" alignSelf="stretch" justify="center">
-              <Icon
-                icon={fileName ? fileIcon : 'CloudUpload'}
-                color={!!errorMessage ? 'error60' : 'dark60'}
-                size={28}
-              />
+              <Icon icon={fileName ? fileIcon : CloudUpload} color={!!errorMessage ? 'error60' : 'dark60'} size={28} />
             </Flex>
             <Flex direction="column" width="100%">
               <Flex direction="row" align="center" width="100%">

--- a/src/components/Dropdown/index.tsx
+++ b/src/components/Dropdown/index.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useMemo } from 'react';
 
 import { Select, MenuItem, type SelectChangeEvent, styled, useTheme, ListItemIcon } from '@mui/material';
+import { Check } from 'tabler-icons-react';
 
 import { type Colors } from '../../theme.types';
 import { automation } from '../../utils';
@@ -109,7 +110,7 @@ export const Dropdown = (props: DropdownProps) => {
             value={option.value}
             style={option.value === value ? { backgroundColor: theme.palette.colors.mintL3 } : {}}
           >
-            <ListItemIcon>{option.value === value && <Icon icon="Check" color="mint90" />}</ListItemIcon>
+            <ListItemIcon>{option.value === value && <Icon icon={Check} color="mint90" />}</ListItemIcon>
             <Typography class="medium" size="base" color="dark90">
               {option.label}
             </Typography>

--- a/src/components/Icon/index.tsx
+++ b/src/components/Icon/index.tsx
@@ -1,24 +1,25 @@
-import React, { useMemo, memo } from 'react';
-
-import * as Icons from 'tabler-icons-react';
+import type React from 'react';
+import { type SVGAttributes } from 'react';
+import { memo } from 'react';
 
 import { colorPalette } from '../../mui-theme';
 import { type Colors } from '../../theme.types';
 
-import * as CustomIcons from './Custom';
+export interface TablerIconProps extends SVGAttributes<SVGElement> {
+  color?: string;
+  size?: string | number;
+}
+export type IconComponent = React.FC<TablerIconProps>;
 
 export type IconProps = {
-  icon: keyof typeof Icons | keyof typeof CustomIcons;
   size?: string | number;
   color: keyof Colors;
+  icon: IconComponent;
   className?: string;
 };
 
-const isIcon = (icon: IconProps['icon']): icon is keyof typeof Icons =>
-  Object.prototype.hasOwnProperty.call(Icons, icon);
-
 function IconNoMemo(props: IconProps) {
-  const IconComponent = useMemo(() => (isIcon(props.icon) ? Icons[props.icon] : CustomIcons[props.icon]), [props.icon]);
+  const { icon: IconComponent } = props;
 
   return <IconComponent color={colorPalette[props.color]} className={props.className} size={props.size} />;
 }

--- a/src/components/ImageUpload.tsx
+++ b/src/components/ImageUpload.tsx
@@ -1,12 +1,14 @@
 import { useCallback } from 'react';
 
 import { styled, useTheme } from '@mui/material';
+import { Loader2, Photo } from 'tabler-icons-react';
 
 import { automation } from '../utils';
 
 import { Button } from './Button';
 import { Flex } from './Flex';
 import { Icon } from './Icon';
+import { ExclamationCircle } from './Icon/Custom';
 import { Typography } from './Typography';
 
 export type ImageUploadProps = {
@@ -69,7 +71,7 @@ export function ImageUpload(props: ImageUploadProps) {
         <>
           {props.errorText && (
             <Flex gap={theme.spacing(0.5)} align="center">
-              <Icon icon="ExclamationCircle" color="error60" size="12px" />
+              <Icon icon={ExclamationCircle} color="error60" size="12px" />
               <Typography class="roman" size="sm" color="error75" padding={0}>
                 {props.errorText}
               </Typography>
@@ -86,13 +88,13 @@ export function ImageUpload(props: ImageUploadProps) {
           >
             {props.src && props.uploading && (
               <LoaderIconWrapper>
-                <Icon icon="Loader2" color="lightWhite" size="24" />
+                <Icon icon={Loader2} color="lightWhite" size="24" />
               </LoaderIconWrapper>
             )}
             {props.src ? (
               <Image src={props.src} />
             ) : (
-              <Icon icon="Photo" size="24px" color={props.error ? 'error60' : 'dark45'} />
+              <Icon icon={Photo} size="24px" color={props.error ? 'error60' : 'dark45'} />
             )}
           </UploadSection>
           {props.canUpload && (

--- a/src/components/KebabMenu/index.tsx
+++ b/src/components/KebabMenu/index.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useMemo, useState } from 'react';
 
 import { Menu, type PaperProps, type PopoverOrigin } from '@mui/material';
+import { Menu2 } from 'tabler-icons-react';
 
 import { Keys } from '../../my-constants';
 import { automation } from '../../utils';
@@ -68,7 +69,7 @@ export const KebabMenu = ({
         })}
         highlight={highlight}
       >
-        <KebabMenuIcon icon="Menu2" color="mint75" />
+        <KebabMenuIcon icon={Menu2} color="mint75" />
       </IconButton>
       <Menu
         id="long-menu"

--- a/src/components/MediaCard.tsx
+++ b/src/components/MediaCard.tsx
@@ -2,6 +2,7 @@ import { useCallback } from 'react';
 import type React from 'react';
 
 import { css, styled } from '@mui/material';
+import { Loader2, PhotoPlus, Reload, X } from 'tabler-icons-react';
 
 import { type Colors } from '../theme.types';
 import { typedMemo } from '../utils';
@@ -54,7 +55,7 @@ const MediaCardNoMemo = <State extends MediaCardState>(props: MediaCardProps<Sta
     return (
       <Wrapper border="mint60" onClick={onClick}>
         <Flex direction="column" justify="center" align="center" height="100%">
-          <Icon icon="PhotoPlus" color="mint75" />
+          <Icon icon={PhotoPlus} color="mint75" />
           <Typography class="medium" size="sm" color="mint75" padding={0.5}>
             Add media
           </Typography>
@@ -68,10 +69,10 @@ const MediaCardNoMemo = <State extends MediaCardState>(props: MediaCardProps<Sta
     return (
       <Wrapper border="error60" onClick={onClick}>
         <RemoveIconWrapper onClick={onRemove}>
-          <Icon icon="X" color="lightL1" size="12px" />
+          <Icon icon={X} color="lightL1" size="12px" />
         </RemoveIconWrapper>
         <Flex direction="column" justify="center" align="center" height="100%" textAlign="center">
-          <Icon icon="Reload" color="error75" />
+          <Icon icon={Reload} color="error75" />
           <Typography class="medium" size="2xs" color="error75" padding={0.5}>
             Unable to upload.
             <br />
@@ -86,13 +87,13 @@ const MediaCardNoMemo = <State extends MediaCardState>(props: MediaCardProps<Sta
     <Wrapper border="dark60" background="dark60">
       {state !== 'locked' && (
         <RemoveIconWrapper onClick={onRemoveWrapper.bind(null, (props as MediaCardProps<typeof state>).onRemove)}>
-          <Icon icon="X" color="lightL1" size="12px" />
+          <Icon icon={X} color="lightL1" size="12px" />
         </RemoveIconWrapper>
       )}
       <ImageWrapper>
         {state === 'uploading' && (
           <LoaderIconWrapper>
-            <Icon icon="Loader2" color="lightWhite" size="24" />
+            <Icon icon={Loader2} color="lightWhite" size="24" />
           </LoaderIconWrapper>
         )}
 

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -1,6 +1,7 @@
 import type React from 'react';
 
 import { Modal as ModalMui, styled, useTheme } from '@mui/material';
+import { X } from 'tabler-icons-react';
 
 import { formatSizeToPx } from '../utils';
 
@@ -38,7 +39,7 @@ export function Modal(props: ModalProps) {
                 {props.title}
               </Typography>
               <StyledIconWrapper onClick={props.onClose}>
-                <Icon icon="X" size="24px" color="dark90" />
+                <Icon icon={X} size="24px" color="dark90" />
               </StyledIconWrapper>
             </Flex>
           </TitleSection>

--- a/src/components/NavigationButton.tsx
+++ b/src/components/NavigationButton.tsx
@@ -2,6 +2,7 @@ import { useCallback, useMemo, memo } from 'react';
 import type React from 'react';
 
 import { styled } from '@mui/material';
+import { ChevronDown, ChevronRight } from 'tabler-icons-react';
 
 import { Flex } from './Flex';
 import { Icon, type IconProps } from './Icon';
@@ -41,7 +42,7 @@ function NavigationButtonNoMemo(props: NavigationButtonProps) {
         </Flex>
         {props.expandable && (
           <div style={{ width: 18, height: 18 }} onClick={onExpandWrapper} className="expand-icon">
-            <Icon icon={props.expanded ? 'ChevronDown' : 'ChevronRight'} color="dark90" size="18" />
+            <Icon icon={props.expanded ? ChevronDown : ChevronRight} color="dark90" size="18" />
           </div>
         )}
       </Flex>

--- a/src/components/PasswordInput/index.tsx
+++ b/src/components/PasswordInput/index.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useState } from 'react';
 
 import { IconButton, InputAdornment, type TextFieldProps } from '@mui/material';
+import { Eye, EyeOff } from 'tabler-icons-react';
 
 import { Icon } from '../Icon';
 import { TextInput, type TextInputProps } from '../TextInput';
@@ -22,7 +23,7 @@ const PasswordInput = (props: PasswordInputProps) => {
         endAdornment: (
           <InputAdornment position="end">
             <IconButton onClick={toggleShowPassword} edge="end">
-              <Icon icon={showPassword ? 'Eye' : 'EyeOff'} color="dark90" />
+              <Icon icon={showPassword ? Eye : EyeOff} color="dark90" />
             </IconButton>
           </InputAdornment>
         ),

--- a/src/components/Select/index.tsx
+++ b/src/components/Select/index.tsx
@@ -8,6 +8,7 @@ import {
   type StylesConfig,
 } from 'react-select/dist/declarations/src';
 import { type StateManagerProps } from 'react-select/dist/declarations/src/useStateManager';
+import { ChevronDown, X } from 'tabler-icons-react';
 
 import { Flex } from '../Flex';
 import { Icon } from '../Icon';
@@ -114,13 +115,13 @@ const StyledDropdownIcon = <IsMulti extends boolean>({
   innerProps,
 }: DropdownIndicatorProps<Option, IsMulti, never>) => (
   <IconStyle {...innerProps}>
-    <Icon icon="ChevronDown" color="dark100" />
+    <Icon icon={ChevronDown} color="dark100" />
   </IconStyle>
 );
 
 const StyledClearIndicator = <IsMulti extends boolean>({ innerProps }: ClearIndicatorProps<Option, IsMulti, never>) => (
   <IconStyle {...innerProps}>
-    <Icon icon="X" color="dark100" />
+    <Icon icon={X} color="dark100" />
   </IconStyle>
 );
 

--- a/src/components/TextInput/Labels.tsx
+++ b/src/components/TextInput/Labels.tsx
@@ -1,5 +1,7 @@
 import React, { memo } from 'react';
 
+import { AlertCircle } from 'tabler-icons-react';
+
 import { Icon } from '../Icon';
 import { Tooltip, type TooltipProps } from '../ToolTip';
 import { Typography } from '../Typography';
@@ -49,7 +51,7 @@ const TextFieldLabelNoMemo = ({
     {tooltip && (
       <Tooltip
         title={tooltip}
-        iconName={tooltipProps?.iconName}
+        icon={tooltipProps?.icon}
         iconColor={tooltipProps?.iconColor}
         iconSize={tooltipProps?.iconSize}
       />
@@ -60,7 +62,7 @@ const TextFieldLabelNoMemo = ({
 const TextFieldErrorLabelNoMemo = ({ errorText }: { errorText: string }) => (
   <RowContainer>
     <HelperTextErrorWrapper align="center" justify="center">
-      <Icon icon="AlertCircle" color="error75" />
+      <Icon icon={AlertCircle} color="error75" />
     </HelperTextErrorWrapper>
     <Typography class="roman" size="sm" color="error75" padding={0}>
       {errorText}

--- a/src/components/TextInput/index.tsx
+++ b/src/components/TextInput/index.tsx
@@ -13,7 +13,7 @@ export type TextInputProps = {
   label: string;
   placeholder?: string;
   value: string;
-  leadingIconName?: IconProps['icon'];
+  leadingIcon?: IconProps['icon'];
   helperText?: string;
   errorText?: string;
   required?: boolean;
@@ -36,7 +36,7 @@ export const TextInput = (props: TextInputProps) => {
     label,
     placeholder,
     value,
-    leadingIconName,
+    leadingIcon,
     helperText = '',
     errorText = '',
     required = false,
@@ -72,14 +72,14 @@ export const TextInput = (props: TextInputProps) => {
         color="primary"
         value={value}
         fullWidth
-        hasLeadingIcon={!!leadingIconName}
+        hasLeadingIcon={!!leadingIcon}
         InputProps={{
           ...InputProps,
           startAdornment: (
             <Adornment
               position="start"
               adornment={startAdornment}
-              icon={leadingIconName}
+              icon={leadingIcon}
               showBorder={showStartAdornmentBorder}
             />
           ),
@@ -113,11 +113,11 @@ const Adornment = ({
 }: {
   adornment?: string | React.ReactNode;
   position: 'start' | 'end';
-  icon?: TextInputProps['leadingIconName'];
+  icon?: TextInputProps['leadingIcon'];
   showBorder?: boolean;
 }) => {
   if (adornment && icon) {
-    throw new Error('cannot have both adornment and leadingIconName');
+    throw new Error('cannot have both adornment and leadingIcon');
   }
   if (icon) {
     return (

--- a/src/components/ToolTip.tsx
+++ b/src/components/ToolTip.tsx
@@ -1,4 +1,5 @@
 import { Tooltip as MuiToolTip, Fade } from '@mui/material';
+import { InfoCircle } from 'tabler-icons-react';
 
 import { type Colors } from '../theme.types';
 import { typedMemo } from '../utils';
@@ -7,7 +8,7 @@ import { Icon, type IconProps } from './Icon';
 
 export type TooltipProps = {
   title?: string;
-  iconName?: IconProps['icon'];
+  icon?: IconProps['icon'];
   iconColor?: keyof Colors;
   iconSize?: number;
 };
@@ -20,17 +21,12 @@ export type TooltipProps = {
  * @param iconName - The name of the icon. Default value is 'InfoCircle'.
  * @param iconSize - The size of the icon. Default value is 12.
  */
-const TooltipNoMemo: React.FC<TooltipProps> = ({
-  title,
-  iconColor = 'dark75',
-  iconName = 'InfoCircle',
-  iconSize = 12,
-}) => {
+const TooltipNoMemo: React.FC<TooltipProps> = ({ title, iconColor = 'dark75', icon = InfoCircle, iconSize = 12 }) => {
   return (
     <span>
       <MuiToolTip title={title} arrow TransitionComponent={Fade} TransitionProps={{ timeout: 600 }}>
         <span>
-          <Icon icon={iconName} color={iconColor} size={iconSize} />
+          <Icon icon={icon} color={iconColor} size={iconSize} />
         </span>
       </MuiToolTip>
     </span>

--- a/src/stories/Icon.stories.tsx
+++ b/src/stories/Icon.stories.tsx
@@ -37,6 +37,9 @@ const IconList = () => {
   );
 };
 
+const isIcon = (icon: keyof typeof Icons | keyof typeof CustomIcons): icon is keyof typeof Icons =>
+  Object.prototype.hasOwnProperty.call(Icons, icon);
+
 const IconWrapperNoMemo = ({ icon }: { icon: keyof typeof Icons | keyof typeof CustomIcons }) => {
   const theme = useTheme();
   return (
@@ -48,7 +51,7 @@ const IconWrapperNoMemo = ({ icon }: { icon: keyof typeof Icons | keyof typeof C
       style={{ padding: theme.spacing(0.5), borderRadius: 4, backgroundColor: theme.palette.colors.dark15 }}
     >
       <div style={{ display: 'flex', flexDirection: 'row', gap: 8 }}>
-        <Icon icon={icon} color="dark90" />
+        <Icon icon={isIcon(icon) ? Icons[icon] : CustomIcons[icon]} color="dark90" />
       </div>
       <Typography color="dark100" class="roman" size="base">
         {icon}

--- a/src/stories/KebabMenu.stories.tsx
+++ b/src/stories/KebabMenu.stories.tsx
@@ -1,4 +1,15 @@
 import { type Meta, type StoryObj } from '@storybook/react';
+import {
+  ArrowForward,
+  Edit,
+  Eye,
+  MailForward,
+  PlayerPause,
+  Reload,
+  SquareRoundedLetterX,
+  Trash,
+  UserCheck,
+} from 'tabler-icons-react';
 
 import { KebabMenu } from '../components/KebabMenu';
 
@@ -29,24 +40,24 @@ export const Main: Story = {
       {
         type: 'VIEW_ORDER',
         label: 'View order',
-        icon: 'Eye',
+        icon: Eye,
         description: 'See a detailed page for this order',
       },
       {
         type: 'REQUEST_REPORT_UPDATE',
         label: 'Request a report update',
-        icon: 'Reload',
+        icon: Reload,
         description: 'Ask for a re-inspection or a free re-upload',
       },
       {
         type: 'SELECT_SUCCESSFUL_BUYER',
         label: 'Select successful buyer',
-        icon: 'UserCheck',
+        icon: UserCheck,
       },
       {
         type: 'SEND_PURCHASE_LINK_LETTER',
         label: 'Send purchase link letter',
-        icon: 'MailForward',
+        icon: MailForward,
         description: 'Share this with interested parties',
       },
     ],
@@ -59,51 +70,51 @@ export const ExtraOptions: Story = {
       {
         type: 'VIEW_ORDER',
         label: 'View order',
-        icon: 'Eye',
+        icon: Eye,
         description: 'See a detailed page for this order',
       },
       {
         type: 'REQUEST_REPORT_UPDATE',
         label: 'Request a report update',
-        icon: 'Reload',
+        icon: Reload,
         description: 'Ask for a re-inspection or a free re-upload',
       },
       {
         type: 'SELECT_SUCCESSFUL_BUYER',
         label: 'Select successful buyer',
-        icon: 'UserCheck',
+        icon: UserCheck,
       },
       {
         type: 'SEND_PURCHASE_LINK_LETTER',
         label: 'Send purchase link letter',
-        icon: 'MailForward',
+        icon: MailForward,
         description: 'Share this with interested parties',
       },
       {
         type: 'CONVERT_TO_BUYER_FREE',
         label: 'Convert to buyer free',
-        icon: 'ArrowForward',
+        icon: ArrowForward,
       },
       {
         type: 'EDIT_ADDRESS',
         label: 'Edit address',
-        icon: 'Edit',
+        icon: Edit,
       },
       {
         type: 'HOLD_REPORT',
         label: 'Put on hold',
-        icon: 'PlayerPause',
+        icon: PlayerPause,
         description: 'this will block re-purchases until resumed',
       },
       {
         type: 'CLOSE_IN_2_DAYS',
         label: 'Close in 2 days',
-        icon: 'SquareRoundedLetterX',
+        icon: SquareRoundedLetterX,
       },
       {
         type: 'CLOSE_NOW',
         label: 'Close now',
-        icon: 'Trash',
+        icon: Trash,
         description: 'this will notify the linked users',
       },
     ],

--- a/src/stories/NavigationMenu.stories.tsx
+++ b/src/stories/NavigationMenu.stories.tsx
@@ -1,5 +1,7 @@
 import { useState } from 'react';
 
+import { BuildingCommunity, User } from 'tabler-icons-react';
+
 import { NavigationMenu } from '../components/NavigationMenu';
 
 import type { Meta, StoryObj } from '@storybook/react';
@@ -22,11 +24,11 @@ const MenuWrapper = () => {
       onClick={setSelected}
       value={selected}
       items={[
-        { label: 'My Account', value: 'my-account', icon: 'User' },
+        { label: 'My Account', value: 'my-account', icon: User },
         {
           label: 'My Company',
           value: 'my-company',
-          icon: 'BuildingCommunity',
+          icon: BuildingCommunity,
           items: [
             { label: 'Company Profile', value: 'profile' },
             { label: 'Company Documents', value: 'documents' },
@@ -40,7 +42,7 @@ const MenuWrapper = () => {
         },
         {
           label: 'My Team',
-          icon: 'User',
+          icon: User,
           value: 'my-team',
           items: [],
         },

--- a/src/stories/PasswordInput.stories.tsx
+++ b/src/stories/PasswordInput.stories.tsx
@@ -1,3 +1,5 @@
+import { EyeCheck } from 'tabler-icons-react';
+
 import { PasswordInput } from '../components/PasswordInput';
 
 import type { Meta, StoryObj } from '@storybook/react';
@@ -13,7 +15,7 @@ export const Active: Story = {
   args: {
     label: 'I am text input',
     placeholder: 'Placeholder',
-    leadingIconName: 'EyeCheck',
+    leadingIconName: EyeCheck,
     helperText: 'Please enter your password.',
     value: 'Ben1234',
     errorText: 'Password didnt match',

--- a/src/stories/PasswordInput.stories.tsx
+++ b/src/stories/PasswordInput.stories.tsx
@@ -15,7 +15,7 @@ export const Active: Story = {
   args: {
     label: 'I am text input',
     placeholder: 'Placeholder',
-    leadingIconName: EyeCheck,
+    leadingIcon: EyeCheck,
     helperText: 'Please enter your password.',
     value: 'Ben1234',
     errorText: 'Password didnt match',

--- a/src/stories/TextInput.stories.tsx
+++ b/src/stories/TextInput.stories.tsx
@@ -53,7 +53,7 @@ export const Email: Story = {
     required: true,
 
     isOptional: false,
-    leadingIconName: Mail,
+    leadingIcon: Mail,
   },
 };
 
@@ -63,7 +63,7 @@ export const TextFieldWithCheckbox: Story = {
     required: true,
 
     isOptional: false,
-    leadingIconName: ChartPie,
+    leadingIcon: ChartPie,
     componentBelowTextField: <Checkbox label="I'm not really sure" size="sm" checked={false} onChange={console.log} />,
   },
 };

--- a/src/stories/TextInput.stories.tsx
+++ b/src/stories/TextInput.stories.tsx
@@ -1,3 +1,5 @@
+import { ChartPie, InfoCircle, Mail, Search } from 'tabler-icons-react';
+
 import { Checkbox } from '../components';
 import { LinkButton } from '../components/LinkButton';
 import { TextInput } from '../components/TextInput';
@@ -26,7 +28,7 @@ export const Active: Story = {
     isOptional: false,
     placeholder: 'Placeholder text',
     tooltipProps: {
-      iconName: 'InfoCircle',
+      icon: InfoCircle,
       iconColor: 'dark75',
       iconSize: 12,
     },
@@ -38,7 +40,7 @@ export const TextAdornment: Story = {
     label: 'Label',
     startAdornment: 'byb.au/',
     endAdornment: (
-      <LinkButton type="grey" size="md" title="Search" leadingIcon="Search" underline={false} onClick={console.log} />
+      <LinkButton type="grey" size="md" title="Search" leadingIcon={Search} underline={false} onClick={console.log} />
     ),
     showStartAdornmentBorder: true,
     showEndAdornmentBorder: true,
@@ -51,7 +53,7 @@ export const Email: Story = {
     required: true,
 
     isOptional: false,
-    leadingIconName: 'Mail',
+    leadingIconName: Mail,
   },
 };
 
@@ -61,7 +63,7 @@ export const TextFieldWithCheckbox: Story = {
     required: true,
 
     isOptional: false,
-    leadingIconName: 'ChartPie',
+    leadingIconName: ChartPie,
     componentBelowTextField: <Checkbox label="I'm not really sure" size="sm" checked={false} onChange={console.log} />,
   },
 };

--- a/src/stories/ToolTip.stories.tsx
+++ b/src/stories/ToolTip.stories.tsx
@@ -1,3 +1,5 @@
+import { InfoCircle } from 'tabler-icons-react';
+
 import { Tooltip } from '../components';
 
 import type { Meta, StoryObj } from '@storybook/react';
@@ -14,7 +16,7 @@ type Story = StoryObj<typeof Tooltip>;
 export const Active: Story = {
   args: {
     title: 'Lorem ipsum',
-    iconName: 'InfoCircle',
+    icon: InfoCircle,
     iconColor: 'dark75',
     iconSize: 12,
   },


### PR DESCRIPTION
Currently the usage of tabler inside ui-lib is used by `import * as icons from 'tabler-icons-react'`, which causes all icons to be included in bundles.

![image](https://github.com/beforeyoubid/ui-lib/assets/67300978/6813db6e-8347-41bd-aca1-a1372a26313f)

this change should mean only specific icons are required from tabler and imported as such -- this approach should mean that bundles can be tree shook natively and the excess icons can be removed from the library