### PR TITLE
Task/improve cjs exports for non index paths

### DIFF
--- a/module_test/RichTextEditor.test.ts
+++ b/module_test/RichTextEditor.test.ts
@@ -1,4 +1,4 @@
-import { RichTextEditor } from '@beforeyoubid/ui-lib/dist/components/RichTextEditor.cjs';
+import { RichTextEditor } from '@beforeyoubid/ui-lib/RichTextEditor';
 
 describe('RichTextEditor', () => {
   it('can be imported', () => {

--- a/module_test/RichTextEditor.tsx
+++ b/module_test/RichTextEditor.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { RichTextEditor } from '@beforeyoubid/ui-lib/dist/components/RichTextEditor';
+import { RichTextEditor } from '@beforeyoubid/ui-lib/RichTextEditor';
 
 export function Editor() {
   return <RichTextEditor />;

--- a/module_test/theme.test.ts
+++ b/module_test/theme.test.ts
@@ -1,4 +1,4 @@
-import { theme } from '@beforeyoubid/ui-lib/dist/mui-theme.cjs';
+import { theme } from '@beforeyoubid/ui-lib/mui-theme';
 
 describe('theme', () => {
   it('can be imported', () => {

--- a/module_test/theme.tsx
+++ b/module_test/theme.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { theme } from '@beforeyoubid/ui-lib/dist/mui-theme';
+import { theme } from '@beforeyoubid/ui-lib/mui-theme';
 import { ThemeProvider } from '@mui/material';
 
 export function Theme({ children }: { children: React.ReactNode }) {

--- a/package.json
+++ b/package.json
@@ -99,6 +99,32 @@
   "files": [
     "dist"
   ],
+  "exports": {
+    ".": {
+      "default": "./dist/index.js",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs",
+      "types": "./dist/index.d.ts"
+    },
+    "./icons": {
+      "default": "./dist/icons.js",
+      "import": "./dist/icons.js",
+      "require": "./dist/icons.cjs",
+      "types": "./dist/icons.d.ts"
+    },
+    "./mui-theme": {
+      "default": "./dist/mui-theme.js",
+      "import": "./dist/mui-theme.js",
+      "require": "./dist/mui-theme.cjs",
+      "types": "./dist/mui-theme.d.ts"
+    },
+    "./RichTextEditor": {
+      "default": "./dist/components/RichTextEditor.js",
+      "import": "./dist/components/RichTextEditor.js",
+      "require": "./dist/components/RichTextEditor.cjs",
+      "types": "./dist/components/RichTextEditor.d.ts"
+    }
+  },
   "resolutions": {
     "strip-ansi": "^6.0.1",
     "string-width": "^4.2.2",


### PR DESCRIPTION
Added explicit import paths to avoid importing via dist path, or needing to control whether CJS or ESM imports are used by way of preprocessor bundling rules