### PR TITLE
improved prop usage for text field

### DIFF
--- a/src/components/TextInput/styles.ts
+++ b/src/components/TextInput/styles.ts
@@ -25,7 +25,9 @@ export const LabelRowContainer = styled('div')<{ required: boolean }>(({ theme, 
   gap: theme.spacing(0.25),
 }));
 
-export const CustomTextField = styled(TextField)<{ hasLeadingIcon: boolean; resize?: React.CSSProperties['resize'] }>`
+export const CustomTextField = styled(TextField, {
+  shouldForwardProp: prop => prop !== 'hasLeadingIcon',
+})<{ hasLeadingIcon: boolean; resize?: React.CSSProperties['resize'] }>`
   & .MuiFormControl-root {
     background: transparent;
   }


### PR DESCRIPTION
added `shouldForwardProp` property to the `TextInput` component.

this is to prevent error messages from being thrown to console unnecessarily.

this is also covered by another WIP PR #134 but this change should target the most obvious use case until this can be resolved properly