### PR TITLE
Task/add functionality to date picker

### DIFF
--- a/src/components/Adornment.tsx
+++ b/src/components/Adornment.tsx
@@ -1,0 +1,66 @@
+import { InputAdornment, styled } from '@mui/material';
+
+import { Icon, type IconProps } from './Icon';
+import { Typography } from './Typography';
+
+export const Adornment = ({
+  adornment,
+  position,
+  icon,
+  showBorder = true,
+}: {
+  adornment?: string | React.ReactNode;
+  position: 'start' | 'end';
+  icon?: IconProps['icon'];
+  showBorder?: boolean;
+}) => {
+  if (adornment && icon) {
+    throw new Error('cannot have both adornment and leadingIcon');
+  }
+  if (icon) {
+    return (
+      <StyledInputAdornment
+        position={position}
+        icon
+        className="icon-adornment"
+        disablePointerEvents
+        showBorder={showBorder}
+      >
+        <Icon icon={icon} color="dark75" size="18" />
+      </StyledInputAdornment>
+    );
+  }
+  if (!adornment) return null;
+  if (!(typeof adornment === 'string')) {
+    return (
+      <StyledInputAdornment position={position} disablePointerEvents showBorder={showBorder}>
+        {adornment}
+      </StyledInputAdornment>
+    );
+  }
+  return (
+    <StyledInputAdornment position={position} showBorder={showBorder}>
+      <Typography color="dark60" class="medium" size="base">
+        {adornment}
+      </Typography>
+    </StyledInputAdornment>
+  );
+};
+
+export const StyledInputAdornment = styled(InputAdornment, {
+  shouldForwardProp: prop => prop !== 'icon' && prop !== 'showBorder',
+})<{ icon?: boolean; showBorder?: boolean }>`
+  position: relative;
+  padding: ${({ theme }) => theme.spacing(0, 1, 0, 1.75)};
+
+  ${({ position }) => (position === 'start' ? ':after' : ':before')} {
+    position: absolute;
+    content: ${({ icon }) => (icon ? 'unset' : `''`)};
+    height: 45px;
+    background-color: ${({ theme }) => theme.palette.colors.dark45};
+    width: 1px;
+    display: ${({ showBorder = true }) => (showBorder ? 'block' : 'none')};
+    ${({ position }) => (position === 'start' ? 'right' : 'left')}: 0;
+    top: -${({ theme }) => theme.spacing(2.75)};
+  }
+`;

--- a/src/components/DatePicker/index.tsx
+++ b/src/components/DatePicker/index.tsx
@@ -1,7 +1,7 @@
 import type React from 'react';
 import { forwardRef, useCallback, useMemo, useState } from 'react';
 
-import { useTheme } from '@mui/material';
+import { type TextFieldProps, useTheme } from '@mui/material';
 import { type DateView, type DatePickerProps as MuiDatePickerProps } from '@mui/x-date-pickers';
 import moment, { type Moment } from 'moment';
 import { CalendarEvent } from 'tabler-icons-react';
@@ -10,6 +10,7 @@ import { automation } from '../../utils';
 import { Flex } from '../Flex';
 import { Icon } from '../Icon';
 import { TextFieldLabel, TextFieldHint, TextFieldErrorLabel } from '../TextInput/Labels';
+import { CustomTextField } from '../TextInput/styles';
 import { type TooltipProps } from '../ToolTip';
 
 import CalendarFooter from './CalendarFooter';
@@ -37,6 +38,8 @@ export type DatePickerProps = {
 
   /** an optional automation key used for providing data attributes to the instances of the component */
   automationKey?: string;
+  /** A react component that will show beneath the text field, good for checkboxes */
+  componentBelowTextField?: React.ReactNode;
 } & Pick<MuiDatePickerProps<moment.Moment>, 'inputRef'>;
 
 const DatePickerNoRef: React.ForwardRefRenderFunction<HTMLInputElement, DatePickerProps> = (
@@ -57,6 +60,7 @@ const DatePickerNoRef: React.ForwardRefRenderFunction<HTMLInputElement, DatePick
     helperText,
     errorText,
     automationKey,
+    componentBelowTextField,
   },
   ref
 ) => {
@@ -113,6 +117,7 @@ const DatePickerNoRef: React.ForwardRefRenderFunction<HTMLInputElement, DatePick
             inputProps: {
               ...automation([automationKey], { label }),
             },
+            helperText: componentBelowTextField,
           },
           popper: {
             sx: {
@@ -207,6 +212,7 @@ const DatePickerNoRef: React.ForwardRefRenderFunction<HTMLInputElement, DatePick
           },
         }}
         slots={{
+          textField: CustomTextField as unknown as React.ElementType<TextFieldProps>,
           layout: props => <CalendarFooter toggleCalendar={toggleOpen}>{props.children}</CalendarFooter>,
           openPickerIcon: () => (
             <Flex onClick={toggleOpen}>

--- a/src/components/DatePicker/index.tsx
+++ b/src/components/DatePicker/index.tsx
@@ -6,6 +6,7 @@ import { type DateView, type DatePickerProps as MuiDatePickerProps } from '@mui/
 import moment, { type Moment } from 'moment';
 import { CalendarEvent } from 'tabler-icons-react';
 
+import { automation } from '../../utils';
 import { Flex } from '../Flex';
 import { Icon } from '../Icon';
 import { TextFieldLabel, TextFieldHint, TextFieldErrorLabel } from '../TextInput/Labels';
@@ -33,6 +34,9 @@ export type DatePickerProps = {
   helperText?: string;
   /** error text to show above the date picker */
   errorText?: string;
+
+  /** an optional automation key used for providing data attributes to the instances of the component */
+  automationKey?: string;
 } & Pick<MuiDatePickerProps<moment.Moment>, 'inputRef'>;
 
 const DatePickerNoRef: React.ForwardRefRenderFunction<HTMLInputElement, DatePickerProps> = (
@@ -105,6 +109,9 @@ const DatePickerNoRef: React.ForwardRefRenderFunction<HTMLInputElement, DatePick
         slotProps={{
           textField: {
             placeholder: format,
+            inputProps: {
+              ...automation([automationKey], { label }),
+            },
           },
           popper: {
             sx: {

--- a/src/components/DatePicker/index.tsx
+++ b/src/components/DatePicker/index.tsx
@@ -8,7 +8,7 @@ import { CalendarEvent } from 'tabler-icons-react';
 
 import { Flex } from '../Flex';
 import { Icon } from '../Icon';
-import { TextFieldLabel } from '../TextInput/Labels';
+import { TextFieldLabel, TextFieldHint, TextFieldErrorLabel } from '../TextInput/Labels';
 import { type TooltipProps } from '../ToolTip';
 
 import CalendarFooter from './CalendarFooter';
@@ -29,6 +29,10 @@ export type DatePickerProps = {
   isOptional?: boolean;
   tooltip?: string;
   tooltipProps?: TooltipProps;
+  /** helper text to show above the date picker */
+  helperText?: string;
+  /** error text to show above the date picker */
+  errorText?: string;
 } & Pick<MuiDatePickerProps<moment.Moment>, 'inputRef'>;
 
 const DatePickerNoRef: React.ForwardRefRenderFunction<HTMLInputElement, DatePickerProps> = (
@@ -46,6 +50,8 @@ const DatePickerNoRef: React.ForwardRefRenderFunction<HTMLInputElement, DatePick
     isOptional = false,
     tooltip,
     tooltipProps,
+    helperText,
+    errorText,
   },
   ref
 ) => {
@@ -84,6 +90,8 @@ const DatePickerNoRef: React.ForwardRefRenderFunction<HTMLInputElement, DatePick
         tooltipProps={tooltipProps}
         isOptional={isOptional}
       />
+      {helperText && <TextFieldHint hintText={helperText} />}
+      {errorText && <TextFieldErrorLabel errorText={errorText} />}
 
       <StyledDatePicker
         value={date}

--- a/src/components/DatePicker/index.tsx
+++ b/src/components/DatePicker/index.tsx
@@ -7,8 +7,9 @@ import moment, { type Moment } from 'moment';
 import { CalendarEvent } from 'tabler-icons-react';
 
 import { automation } from '../../utils';
+import { Adornment } from '../Adornment';
 import { Flex } from '../Flex';
-import { Icon } from '../Icon';
+import { Icon, type IconProps } from '../Icon';
 import { TextFieldLabel, TextFieldHint, TextFieldErrorLabel } from '../TextInput/Labels';
 import { CustomTextField } from '../TextInput/styles';
 import { type TooltipProps } from '../ToolTip';
@@ -38,6 +39,13 @@ export type DatePickerProps = {
 
   /** an optional automation key used for providing data attributes to the instances of the component */
   automationKey?: string;
+  /** icon at start of input field */
+  leadingIcon?: IconProps['icon'];
+
+  /** the adornment at the start of the input field */
+  startAdornment?: string | React.ReactNode;
+  /** whether to add a border around the start adornment */
+  showStartAdornmentBorder?: boolean;
   /** A react component that will show beneath the text field, good for checkboxes */
   componentBelowTextField?: React.ReactNode;
 } & Pick<MuiDatePickerProps<moment.Moment>, 'inputRef'>;
@@ -59,7 +67,10 @@ const DatePickerNoRef: React.ForwardRefRenderFunction<HTMLInputElement, DatePick
     tooltipProps,
     helperText,
     errorText,
+    startAdornment,
+    showStartAdornmentBorder = true,
     automationKey,
+    leadingIcon,
     componentBelowTextField,
   },
   ref
@@ -118,6 +129,16 @@ const DatePickerNoRef: React.ForwardRefRenderFunction<HTMLInputElement, DatePick
               ...automation([automationKey], { label }),
             },
             helperText: componentBelowTextField,
+            InputProps: {
+              startAdornment: (
+                <Adornment
+                  position="start"
+                  adornment={startAdornment}
+                  icon={leadingIcon}
+                  showBorder={showStartAdornmentBorder}
+                />
+              ),
+            },
           },
           popper: {
             sx: {

--- a/src/components/DatePicker/index.tsx
+++ b/src/components/DatePicker/index.tsx
@@ -56,6 +56,7 @@ const DatePickerNoRef: React.ForwardRefRenderFunction<HTMLInputElement, DatePick
     tooltipProps,
     helperText,
     errorText,
+    automationKey,
   },
   ref
 ) => {

--- a/src/components/TextInput/index.tsx
+++ b/src/components/TextInput/index.tsx
@@ -1,13 +1,13 @@
 import { type StandardTextFieldProps, useTheme } from '@mui/material';
 
 import { automation } from '../../utils';
+import { Adornment } from '../Adornment';
 import { Flex } from '../Flex';
-import { Icon, type IconProps } from '../Icon';
+import { type IconProps } from '../Icon';
 import { type TooltipProps } from '../ToolTip';
-import { Typography } from '../Typography';
 
 import { TextFieldErrorLabel, TextFieldHint, TextFieldLabel } from './Labels';
-import { CustomTextField, StyledInputAdornment } from './styles';
+import { CustomTextField } from './styles';
 
 export type TextInputProps = {
   label: string;
@@ -102,49 +102,5 @@ export const TextInput = (props: TextInputProps) => {
         {...rest}
       />
     </Flex>
-  );
-};
-
-const Adornment = ({
-  adornment,
-  position,
-  icon,
-  showBorder = true,
-}: {
-  adornment?: string | React.ReactNode;
-  position: 'start' | 'end';
-  icon?: TextInputProps['leadingIcon'];
-  showBorder?: boolean;
-}) => {
-  if (adornment && icon) {
-    throw new Error('cannot have both adornment and leadingIcon');
-  }
-  if (icon) {
-    return (
-      <StyledInputAdornment
-        position={position}
-        icon
-        className="icon-adornment"
-        disablePointerEvents
-        showBorder={showBorder}
-      >
-        <Icon icon={icon} color="dark75" size="18" />
-      </StyledInputAdornment>
-    );
-  }
-  if (!adornment) return null;
-  if (!(typeof adornment === 'string')) {
-    return (
-      <StyledInputAdornment position={position} disablePointerEvents showBorder={showBorder}>
-        {adornment}
-      </StyledInputAdornment>
-    );
-  }
-  return (
-    <StyledInputAdornment position={position} showBorder={showBorder}>
-      <Typography color="dark60" class="medium" size="base">
-        {adornment}
-      </Typography>
-    </StyledInputAdornment>
   );
 };

--- a/src/components/TextInput/styles.ts
+++ b/src/components/TextInput/styles.ts
@@ -1,4 +1,4 @@
-import { InputAdornment, TextField, styled } from '@mui/material';
+import { TextField, styled } from '@mui/material';
 
 import { Flex } from '../Flex';
 
@@ -94,21 +94,5 @@ export const CustomTextField = styled(TextField, {
       background-color: ${({ error, disabled, theme }) =>
         disabled ? theme.palette.colors.dark45 : error ? theme.palette.colors.error60 : theme.palette.colors.mint60};
     }
-  }
-`;
-
-export const StyledInputAdornment = styled(InputAdornment)<{ icon?: boolean; showBorder?: boolean }>`
-  position: relative;
-  padding: ${({ theme }) => theme.spacing(0, 1, 0, 1.75)};
-
-  ${({ position }) => (position === 'start' ? ':after' : ':before')} {
-    position: absolute;
-    content: ${({ icon }) => (icon ? 'unset' : `''`)};
-    height: 45px;
-    background-color: ${({ theme }) => theme.palette.colors.dark45};
-    width: 1px;
-    display: ${({ showBorder = true }) => (showBorder ? 'block' : 'none')};
-    ${({ position }) => (position === 'start' ? 'right' : 'left')}: 0;
-    top: -${({ theme }) => theme.spacing(2.75)};
   }
 `;

--- a/src/stories/DatePicker.stories.tsx
+++ b/src/stories/DatePicker.stories.tsx
@@ -3,7 +3,9 @@ import { useCallback, useState } from 'react';
 import { LocalizationProvider } from '@mui/x-date-pickers';
 import { AdapterMoment } from '@mui/x-date-pickers/AdapterMoment';
 import moment, { type Moment } from 'moment';
+import { HomeQuestion } from 'tabler-icons-react';
 
+import { Checkbox, Flex } from '../components';
 import { DatePicker } from '../components/DatePicker';
 
 import type { Meta, StoryObj } from '@storybook/react';
@@ -85,5 +87,37 @@ export const ExpirationLabel: Story = {
     onChange: value => {
       console.log('Selected value:', value);
     },
+  },
+};
+
+export const HelperText: Story = {
+  args: {
+    label: 'Due Date',
+    helperText: 'The date the project is due by',
+  },
+};
+
+export const ErrorText: Story = {
+  args: {
+    label: 'Due Date',
+    helperText: 'The date the project is due by',
+    errorText: 'This project due date is in the past. Please pick a date in the future',
+    date: moment('2000-01-01'),
+    leadingIcon: HomeQuestion,
+  },
+};
+
+export const CheckboxBelowTextField: Story = {
+  args: {
+    label: 'Due Date',
+    helperText: 'The date the project is due by',
+    errorText: 'This project due date is in the past. Please pick a date in the future',
+    date: moment('2000-01-01'),
+    leadingIcon: HomeQuestion,
+    componentBelowTextField: (
+      <Flex direction="row" align="center" gap={8}>
+        <Checkbox size="sm" label="Not applicable" checked={false} onChange={console.log} />
+      </Flex>
+    ),
   },
 };

--- a/src/stories/DatePicker.stories.tsx
+++ b/src/stories/DatePicker.stories.tsx
@@ -54,6 +54,11 @@ const DatePickerStory = () => {
 const meta: Meta<typeof DatePicker> = {
   component: DatePickerStory,
   title: 'Input/DatePicker',
+  argTypes: {
+    componentBelowTextField: {
+      table: { disable: true },
+    },
+  },
 };
 
 export default meta;

--- a/src/stories/DatePicker.stories.tsx
+++ b/src/stories/DatePicker.stories.tsx
@@ -8,7 +8,7 @@ import { DatePicker } from '../components/DatePicker';
 
 import type { Meta, StoryObj } from '@storybook/react';
 
-const DatePickerStory = () => {
+const DatePickerStory = (props: object) => {
   const [date, setDate] = useState<Maybe<moment.MomentInput>>(null);
 
   const handleChange = (value: unknown) => {
@@ -45,7 +45,7 @@ const DatePickerStory = () => {
         incrementYear={incrementYear}
         decrementYear={decrementYear}
         onChange={handleChange}
-        tooltip="The date the inspection was performed."
+        {...props}
       />
     </LocalizationProvider>
   );


### PR DESCRIPTION
`DatePicker`:
- added adornment support (only start adornment as end adornment is covered by the icon)
- added support for helper text
- added support for error text
- added support for `automationKey` prop
- added support for component underneath input field (usually a checkbox or similar)

example:

![image](https://github.com/beforeyoubid/ui-lib/assets/67300978/9c952c9b-192a-45bc-a62f-531aa7620503)

`TextInput`:
- cleaned up adornment usage in TextField (moved it to a new file)