### PR TITLE
fixed invalid date on the DatePicker's CalendarHeader

### DIFF
--- a/src/components/DatePicker/index.tsx
+++ b/src/components/DatePicker/index.tsx
@@ -17,6 +17,7 @@ import { type TooltipProps } from '../ToolTip';
 import CalendarFooter from './CalendarFooter';
 import CalendarHeader from './CalendarHeader';
 import { StyledDatePicker } from './styles';
+import { isInvalidDate } from './utils';
 
 export type DatePickerProps = {
   label: string;
@@ -82,8 +83,16 @@ const DatePickerNoRef: React.ForwardRefRenderFunction<HTMLInputElement, DatePick
   const [isOpen, setIsOpen] = useState(false);
   const [currentView, setCurrentView] = useState<DateView>('day');
 
-  const dateMonth = useMemo(() => date?.format('MMM') ?? moment().format('MMM'), [date]);
-  const dateYear = useMemo(() => date?.format('YYYY') ?? moment().format('YYYY'), [date]);
+  const dateMonth = useMemo(
+    // eslint-disable-next-line import/no-named-as-default-member
+    () => (isInvalidDate(date) && moment.isMoment(date) ? date.format('MMM') : moment().format('MMM')),
+    [date]
+  );
+  const dateYear = useMemo(
+    // eslint-disable-next-line import/no-named-as-default-member
+    () => (isInvalidDate(date) && moment.isMoment(date) ? date.format('YYYY') : moment().format('YYYY')),
+    [date]
+  );
 
   const toggleMonthView = useCallback(() => {
     setCurrentView(currView => (currView === 'month' ? 'day' : 'month'));

--- a/src/components/DatePicker/utils.ts
+++ b/src/components/DatePicker/utils.ts
@@ -1,0 +1,18 @@
+import moment from 'moment';
+
+import { empty } from '../../utils';
+
+/**
+ * util function to check whether the date is Invalid
+ * @param date the date to check
+ * @returns a boolean of whether the date is invalid
+ */
+export const isInvalidDate = (date: Maybe<Date | moment.MomentInput | moment.Moment>): boolean => {
+  if (empty(date)) return true;
+  // eslint-disable-next-line import/no-named-as-default-member
+  if (moment.isMoment(date)) {
+    return date.isValid();
+  }
+
+  return moment(date).isValid();
+};

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,6 +3,8 @@ import { memo } from 'react';
 export const isEvenNum = (num: number) => num % 2 === 0;
 export const typedMemo: <T>(c: T) => T = memo;
 
+export const empty = <TValue>(value: TValue | null | undefined): value is null | undefined =>
+  value === null || value === undefined;
 export const notEmpty = <TValue>(value: TValue | null | undefined): value is TValue =>
   value !== null && value !== undefined;
 


### PR DESCRIPTION
this is a small fix to prevent "Invalid date" from showing in the CalendarHeader

this happens when the `date` parameter is a moment object that is invalid.

FWIW in separate implementations, we found that the `decrementYear` / `decrementMonth` / `incrementMonth` / `incrementYear` functions would try to modify a `null` value like it was a moment object, rendering it invalid.

if an invalid date is passed in, it breaks the variables responding for printing the month & year in the calendar picker

this is fixed by checking inside the component if the `date` property is invalid, and if so, reverting to the current date / year

this is not ideal, as if someone tries to increment/decrement a month or year that represents now, that indicates they are choosing the date, with that in mind, I think it's worth setting the value on the date as if they were transforming from the default value, but this cannot be done without moving the decrement & increment functions inside the function, as they have no variables in their signature from material-ui or onwards

this is a breaking API change for the DatePicker, so it makes sense to fix separately (and bump minor version)