### PR TITLE
add ID prop to DocumentUploadCard

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@beforeyoubid/ui-lib",
-  "version": "2.2.8",
+  "version": "2.3.0",
   "engines": {
     "node": ">=18.0.0"
   },

--- a/src/__tests__/components/DocumentUploadCard.test.tsx
+++ b/src/__tests__/components/DocumentUploadCard.test.tsx
@@ -11,6 +11,7 @@ describe('DocumentUploadCard', () => {
           label="Label"
           description="Provide a description for your file upload"
           isEditing
+          id="test1"
           fileUrl=""
           fileName=""
           fileSize=""
@@ -32,6 +33,7 @@ describe('DocumentUploadCard', () => {
           label="Label"
           description="Provide a description for your file upload"
           isEditing
+          id="test1"
           fileUrl="https://www.w3.org/WAI/ER/tests/xhtml/testfiles/resources/pdf/dummy.pdf"
           fileName="dummy.pdf"
           fileSize="200 KB"
@@ -53,6 +55,7 @@ describe('DocumentUploadCard', () => {
           label="Label"
           description="Provide a description for your file upload"
           isEditing
+          id="test1"
           fileUrl="https://www.w3.org/WAI/ER/tests/xhtml/testfiles/resources/pdf/dummy.pdf"
           fileName="dummy.pdf"
           fileSize="200 KB"
@@ -74,6 +77,7 @@ describe('DocumentUploadCard', () => {
           label="Label"
           description="Provide a description for your file upload"
           isEditing
+          id="test1"
           fileUrl="https://www.w3.org/WAI/ER/tests/xhtml/testfiles/resources/pdf/dummy.pdf"
           fileName="dummy.pdf"
           fileSize="200 KB"
@@ -95,6 +99,7 @@ describe('DocumentUploadCard', () => {
           label="Label"
           description="Provide a description for your file upload"
           isEditing={false}
+          id="test1"
           fileUrl="https://www.w3.org/WAI/ER/tests/xhtml/testfiles/resources/pdf/dummy.pdf"
           fileName="dummy.pdf"
           fileSize="200 KB"

--- a/src/components/DocumentUploadCard/RightContent/Upload.tsx
+++ b/src/components/DocumentUploadCard/RightContent/Upload.tsx
@@ -17,12 +17,14 @@ import { Flex } from '../../Flex';
 
 type UploadProps = {
   dataComponentKey?: string;
+  id: string;
   accept?: string;
   onSelect: (file: File) => void;
 };
 
 const UploadNoMemo: React.FC<UploadProps> = ({
   dataComponentKey = 'upload-file-button',
+  id,
   accept = '.pdf',
   onSelect,
 }) => {
@@ -40,12 +42,12 @@ const UploadNoMemo: React.FC<UploadProps> = ({
     <Flex direction="row">
       <HiddenInput
         type="file"
-        id={dataComponentKey}
+        id={id}
         data-component-key={dataComponentKey}
         accept={accept}
         onChange={handleFileSelect}
       />
-      <Label htmlFor={dataComponentKey}>
+      <Label htmlFor={id}>
         <Button
           disabled
           title="Upload file"

--- a/src/components/DocumentUploadCard/index.tsx
+++ b/src/components/DocumentUploadCard/index.tsx
@@ -24,6 +24,8 @@ export type DocumentUploadCardProps = {
   uploadProgress?: number;
   errorMessage?: string; // indicates an error occurred
   uploadButtonDataComponentKey?: string;
+  /** an ID to put on the input component -- this is needed to join the input upload to the form controller */
+  id: string;
   onFileSelect: (file: File) => void;
   onFileDelete: () => void;
 };
@@ -40,6 +42,7 @@ export const DocumentUploadCard: React.FC<DocumentUploadCardProps> = ({
   fileSize,
   errorMessage,
   isUploading,
+  id,
   uploadButtonDataComponentKey,
   uploadProgress = 0,
   onFileSelect,
@@ -87,7 +90,12 @@ export const DocumentUploadCard: React.FC<DocumentUploadCardProps> = ({
                 <LeftContent fileName={fileName} fileSize={fileSize} hasError={!!errorMessage} />
                 {/* right content */}
                 {!isUploading && !fileUrl && (
-                  <Upload dataComponentKey={uploadButtonDataComponentKey} accept={accept} onSelect={onFileSelect} />
+                  <Upload
+                    dataComponentKey={uploadButtonDataComponentKey}
+                    id={id}
+                    accept={accept}
+                    onSelect={onFileSelect}
+                  />
                 )}
                 {isUploading && <Uploading progress={uploadProgress} />}
                 {fileUrl && <Uploaded onFileDelete={onFileDelete} />}


### PR DESCRIPTION
we identified that duplicate IDs would cause uploads to be mistaken between inputs.

this change adds a mandatory prop to DocumentUploadCard for an ID