### PR TITLE
feat: Add optional calendar icon to DateField for SRWS

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@beforeyoubid/ui-lib",
-  "version": "2.3.4",
+  "version": "2.3.5",
   "engines": {
     "node": ">=18.0.0"
   },

--- a/src/components/DatePicker/DateField.tsx
+++ b/src/components/DatePicker/DateField.tsx
@@ -4,6 +4,7 @@ import { forwardRef, useMemo } from 'react';
 import { type TextFieldProps } from '@mui/material';
 import { type DateFieldProps as MuiDateFieldProps } from '@mui/x-date-pickers';
 import moment, { type Moment } from 'moment';
+import { CalendarEvent } from 'tabler-icons-react';
 
 import { automation } from '../../utils';
 import { Adornment } from '../Adornment';
@@ -38,6 +39,8 @@ export type DateFieldProps = {
   startAdornment?: string | React.ReactNode;
   /** whether to add a border around the start adornment */
   showStartAdornmentBorder?: boolean;
+  /** whether to show default calendar icon on the right */
+  showCalendarIcon?: boolean;
   /** A react component that will show beneath the text field, good for checkboxes */
   componentBelowTextField?: React.ReactNode;
 } & Pick<MuiDateFieldProps<moment.Moment>, 'inputRef' | 'disabled'>;
@@ -57,6 +60,7 @@ const DateFieldNoRef: React.ForwardRefRenderFunction<HTMLInputElement, DateField
     errorText,
     startAdornment,
     showStartAdornmentBorder = true,
+    showCalendarIcon = false,
     automationKey,
     leadingIcon,
     componentBelowTextField,
@@ -99,6 +103,9 @@ const DateFieldNoRef: React.ForwardRefRenderFunction<HTMLInputElement, DateField
                   showBorder={showStartAdornmentBorder}
                 />
               ),
+              endAdornment: showCalendarIcon ? (
+                <Adornment position="end" icon={CalendarEvent} showBorder={false} />
+              ) : null,
             },
           },
         }}

--- a/src/components/DatePicker/styles.tsx
+++ b/src/components/DatePicker/styles.tsx
@@ -76,7 +76,7 @@ export const StyledDateField = styled(DateField<Moment>)(({ theme }) => ({
   position: 'relative',
   width: '100%',
   ' .MuiInputBase-input': {
-    padding: theme.spacing(1.5, 1.75, 1.5, 1.25),
+    padding: theme.spacing(1.5, 0.5, 1.5, 1.25),
   },
   '&.MuiFormControl-root *': {
     border: 'none',
@@ -95,6 +95,9 @@ export const StyledDateField = styled(DateField<Moment>)(({ theme }) => ({
     fontFamily: theme.typography.fonts['roman'],
     fontSize: theme.typography.size.base.fontSize,
     color: theme.palette.colors.dark90,
+  },
+  '&.MuiFormControl-root .MuiInputBase-root .MuiInputAdornment-root': {
+    marginRight: theme.spacing(1.5),
   },
 }));
 


### PR DESCRIPTION
- Add showCalendarIcon prop to DateField (defaults to false)
- Update DateField styles for proper calendar icon spacing
- Calendar icon only appears when explicitly enabled via prop
- Zero impact on existing consumers (backward compatible)